### PR TITLE
Make go get compatible

### DIFF
--- a/go-get.go
+++ b/go-get.go
@@ -1,0 +1,6 @@
+// This file is here so go get succeeds, as without it errors with:
+// no buildable Go source files in ...
+//
+// +build !windows
+
+package wmi

--- a/wmi.go
+++ b/wmi.go
@@ -1,25 +1,25 @@
-/*
-Package wmi provides a WQL interface for WMI on Windows.
+// Package wmi provides a WQL interface for WMI on Windows.
+//
+// Example code to print names of running processes:
+//
+// 	type Win32_Process struct {
+// 		Name string
+// 	}
+//
+// 	func main() {
+// 		var dst []Win32_Process
+// 		q := wmi.CreateQuery(&dst, "")
+// 		err := wmi.Query(q, &dst)
+// 		if err != nil {
+// 			log.Fatal(err)
+// 		}
+// 		for i, v := range dst {
+// 			println(i, v.Name)
+// 		}
+// 	}
+//
+// +build windows
 
-Example code to print names of running processes:
-
-	type Win32_Process struct {
-		Name string
-	}
-
-	func main() {
-		var dst []Win32_Process
-		q := wmi.CreateQuery(&dst, "")
-		err := wmi.Query(q, &dst)
-		if err != nil {
-			log.Fatal(err)
-		}
-		for i, v := range dst {
-			println(i, v.Name)
-		}
-	}
-
-*/
 package wmi
 
 import (
@@ -255,7 +255,7 @@ func loadEntity(dst interface{}, src *ole.IDispatch) (errFieldMismatch error) {
 						if err != nil {
 							return err
 						}
-						val = val[:22] + fmt.Sprintf("%02d%02d", mins / 60, mins % 60)
+						val = val[:22] + fmt.Sprintf("%02d%02d", mins/60, mins%60)
 					}
 					t, err := time.Parse("20060102150405.000000-0700", val)
 					if err != nil {

--- a/wmi_test.go
+++ b/wmi_test.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package wmi
 
 import (


### PR DESCRIPTION
Added +build windows to all existing source files.

Added go-get.go which compiles for !windows so there is at least one file to compile.

The one line other change was due to go fmt hence its a no-op.