### PR TITLE
add Release calls for service and result IDispatch object

### DIFF
--- a/wmi.go
+++ b/wmi.go
@@ -362,6 +362,21 @@ func (c *Client) loadEntity(dst interface{}, src *ole.IDispatch) (errFieldMismat
 				}
 			}
 		default:
+			// Only support []string slices for now
+			if f.Kind() == reflect.Slice && f.Type().Elem().Kind() == reflect.String {
+				safeArray := prop.ToArray()
+				if safeArray != nil {
+					arr := safeArray.ToValueArray()
+					fArr := reflect.MakeSlice(f.Type(), len(arr), len(arr))
+					for i, v := range arr {
+						s := fArr.Index(i)
+						s.SetString(v.(string))
+					}
+					f.Set(fArr)
+					break
+				}
+			}
+
 			typeof := reflect.TypeOf(val)
 			if typeof == nil && (isPtr || c.NonePtrZero) {
 				if (isPtr && c.PtrNil) || (!isPtr && c.NonePtrZero) {

--- a/wmi.go
+++ b/wmi.go
@@ -158,16 +158,18 @@ func (c *Client) Query(query string, dst interface{}, connectServerArgs ...inter
 	if err != nil {
 		return err
 	}
-	service := serviceRaw.ToIDispatch()
 	defer serviceRaw.Clear()
+	service := serviceRaw.ToIDispatch()
+	defer service.Release()
 
 	// result is a SWBemObjectSet
 	resultRaw, err := oleutil.CallMethod(service, "ExecQuery", query)
 	if err != nil {
 		return err
 	}
-	result := resultRaw.ToIDispatch()
 	defer resultRaw.Clear()
+	result := resultRaw.ToIDispatch()
+	defer result.Release()
 
 	count, err := oleInt64(result, "Count")
 	if err != nil {


### PR DESCRIPTION
We notices a memory leak running Scollector on Windows Server 2016. Not sure what changed, but I think there should be Release calls for any IDispatch objects, so adding those and running some tests.

Note this also includes the string slices commit that is already on the next branch. That commit has been tested and is ready to merge.