### PR TITLE
Skip assignment of null values from WMI

### DIFF
--- a/wmi.go
+++ b/wmi.go
@@ -285,6 +285,10 @@ func (c *Client) loadEntity(dst interface{}, src *ole.IDispatch) (errFieldMismat
 		}
 		defer prop.Clear()
 
+		if prop.Value() == nil {
+			continue
+		}
+
 		switch val := prop.Value().(type) {
 		case int8, int16, int32, int64, int:
 			v := reflect.ValueOf(val).Int()


### PR DESCRIPTION
Some tables can return null values for typed fields. As it currently stands, https://github.com/StackExchange/wmi/blob/5d049714c4a64225c3c79a7cf7d02f7fb5b96338/wmi.go#L249 shows an error that the field cannot be assigned a value of `<nil>`. This means that for 1 `nil` property, the entire object doesn't get populated. This PR adds a `nil` check before assignment, and if the field is `nil`, then it skips assignment and continues to the next field (leaving field on the destination object at its default value).

I'm not sure what the desired behavior would be here, but wanted to submit the PR in case it's helpful. The current behavior (the entire destination object is not populated) doesn't seem ideal, but the behavior of this PR (populating the destination object, but leaving `nil` values from the source at their default value) may be confusing. We could create nullable types for use with the struct representing the WMI fields (which would more accurately represent the WMI source values), but that would add a lot of complexity and non-obviousness.