### PR TITLE
fix support for slices

### DIFF
--- a/wmi.go
+++ b/wmi.go
@@ -285,7 +285,7 @@ func (c *Client) loadEntity(dst interface{}, src *ole.IDispatch) (errFieldMismat
 		}
 		defer prop.Clear()
 
-		if prop.Value() == nil {
+		if prop.VT == 0x1 { //VT_NULL
 			continue
 		}
 


### PR DESCRIPTION
Hi!
Looks like previous PR https://github.com/StackExchange/wmi/pull/38 breaks functionality from PR https://github.com/StackExchange/wmi/pull/19. String arrays, like IP addreses from Win32_NetworkAdapterConfiguration are empty now.

I've tried to understand what's wrong and found, that prop.Value() for array is **nil**, but prop type is VT_ARRAY, so I've changed condition to check if prop is actually VT_NULL. 

It works on my machine (c), but I'm not a golang guru, so please double check, if I break something else.
