### PR TITLE
Add support for slices of other uint and int types

### DIFF
--- a/wmi.go
+++ b/wmi.go
@@ -387,7 +387,7 @@ func (c *Client) loadEntity(dst interface{}, src *ole.IDispatch) (errFieldMismat
 						}
 						f.Set(fArr)
 					}
-				case reflect.Uint8:
+				case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
 					safeArray := prop.ToArray()
 					if safeArray != nil {
 						arr := safeArray.ToValueArray()
@@ -395,6 +395,17 @@ func (c *Client) loadEntity(dst interface{}, src *ole.IDispatch) (errFieldMismat
 						for i, v := range arr {
 							s := fArr.Index(i)
 							s.SetUint(reflect.ValueOf(v).Uint())
+						}
+						f.Set(fArr)
+					}
+				case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+					safeArray := prop.ToArray()
+					if safeArray != nil {
+						arr := safeArray.ToValueArray()
+						fArr := reflect.MakeSlice(f.Type(), len(arr), len(arr))
+						for i, v := range arr {
+							s := fArr.Index(i)
+							s.SetInt(reflect.ValueOf(v).Int())
 						}
 						f.Set(fArr)
 					}


### PR DESCRIPTION
This change adds support other int and unit slice types. Previously, only uint8 was supported. 