### PR TITLE
Detect if a DLL is constructed for graphic application.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 wmi
 ===
 
-Package wmi provides a WQL interface for WMI on Windows.
+Package wmi provides a WQL interface to Windows WMI.
+
+Note: It interfaces with WMI on the local machine, therefore it only runs on Windows.

--- a/swbemservices.go
+++ b/swbemservices.go
@@ -77,7 +77,7 @@ func (s *SWbemServices) process(initError chan error) {
 	//fmt.Println("process: starting background thread initialization")
 	//All OLE/WMI calls must happen on the same initialized thead, so lock this goroutine
 	runtime.LockOSThread()
-	defer runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	err := ole.CoInitializeEx(0, ole.COINIT_MULTITHREADED)
 	if err != nil {

--- a/wmi.go
+++ b/wmi.go
@@ -387,7 +387,7 @@ func (c *Client) loadEntity(dst interface{}, src *ole.IDispatch) (errFieldMismat
 						}
 						f.Set(fArr)
 					}
-				case reflect.Uint8:
+				case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
 					safeArray := prop.ToArray()
 					if safeArray != nil {
 						arr := safeArray.ToValueArray()
@@ -395,6 +395,17 @@ func (c *Client) loadEntity(dst interface{}, src *ole.IDispatch) (errFieldMismat
 						for i, v := range arr {
 							s := fArr.Index(i)
 							s.SetUint(reflect.ValueOf(v).Uint())
+						}
+						f.Set(fArr)
+					}
+				case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+					safeArray := prop.ToArray()
+					if safeArray != nil {
+						arr := safeArray.ToValueArray()
+						fArr := reflect.MakeSlice(f.Type(), len(arr), len(arr))
+						for i, v := range arr {
+							s := fArr.Index(i)
+							s.SetInt(reflect.ValueOf(v).Int())
 						}
 						f.Set(fArr)
 					}


### PR DESCRIPTION
I had some problems creating a DLL, because I used it in a Graphical application and it generated errors because of the call to the Coinitialize function. where the call should be omitted so that the error did not appear.

**I rely on this question from stackoverflow.com
https://stackoverflow.com/questions/2453973/using-dll-that-using-com-in-c-sharp**

the changes affect wmi.go 

I have attached the modified code where you can optionally put it if the app is GUI.
[wmi.txt](https://github.com/StackExchange/wmi/files/4211863/wmi.txt)


