### PR TITLE
fix `go get -u ./...` path error when parsing go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module wmi
+module github.com/StackExchange/wmi
 
 go 1.13


### PR DESCRIPTION
```
go get: github.com/StackExchange/wmi@v0.0.0-20190523213315-cbe66965904d updating to
	github.com/StackExchange/wmi@v0.0.0-20210708210415-b284ef6ab838: parsing go.mod:
	module declares its path as: wmi
	        but was required as: github.com/StackExchange/wmi
```